### PR TITLE
Fix opening of Z-stack, single-T images

### DIFF
--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -85,7 +85,7 @@ def load_omero_channel(
         size_x = image.getPixelSizeX()
         size_z = image.getPixelSizeZ()
         if size_x is not None and size_z is not None:
-            if image.getSizeC() > 1:
+            if image.getSizeT() > 1:
                 scale = [1, size_z / size_x, 1, 1]
             else:
                 scale = [size_z / size_x, 1, 1]


### PR DESCRIPTION
This fixes opening of Z-stack images (single T).

Currently the `get_data_lazy()` returns a different shape of dask array, depending on `sizeT`.
SizeC is not handled here since we are always just getting the data for a single channel.

This is a quick fix, but I would prefer to have `get_data_lazy()` always return a 5D array of shape `(t, c, z, y, x)` to be consistent with the ome-zarr spec.
This will avoid having to check which dimensions are which elsewhere.