### PR TITLE
Omero tree fixes

### DIFF
--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -85,7 +85,7 @@ def load_omero_channel(
         size_x = image.getPixelSizeX()
         size_z = image.getPixelSizeZ()
         if size_x is not None and size_z is not None:
-            if image.getSizeC() > 1:
+            if image.getSizeT() > 1:
                 scale = [1, size_z / size_x, 1, 1]
             else:
                 scale = [size_z / size_x, 1, 1]

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -1,9 +1,9 @@
 import atexit
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple, Generator
 
 from napari.qt.threading import WorkerBase, create_worker
 from omero.clients import BaseClient
-from omero.gateway import BlitzGateway, PixelsWrapper
+from omero.gateway import BlitzGateway, PixelsWrapper, BlitzObjectWrapper
 import omero.gateway
 from omero.util.sessions import SessionsStore
 from qtpy.QtCore import QObject, Signal
@@ -168,6 +168,13 @@ class QGateWay(QObject):
         self.connected.emit(self.conn)
         self.status.emit("")
         return self.conn
+
+    def getObjects(
+        self, name: str, **kwargs
+    ) -> Generator[BlitzObjectWrapper, None, None]:
+        if not self.isConnected():
+            raise RuntimeError("No connection!")
+        yield from self.conn.getObjects(name, **kwargs)
 
 
 class NonCachedPixelsWrapper(PixelsWrapper):

--- a/src/napari_omero/widgets/main.py
+++ b/src/napari_omero/widgets/main.py
@@ -61,11 +61,13 @@ class OMEROWidget(QWidget):
         if not self.thumb_grid.selectedItems():
             return
         wrapper = self.thumb_grid.selectedItems()[0].wrapper
-        index: QModelIndex = self.model._wrapper_map[wrapper.getId()]
-        self.tree.selectionModel().select(
-            index,
-            QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows,
-        )
+        index: QModelIndex = self.model._wrapper_map.get(wrapper.getId())
+        if index:
+            self.tree.selectionModel().select(
+                index,
+                QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows,
+            )
+        self.load_image(wrapper)
 
     def _on_tree_selection(
         self, selected: QItemSelection, deselected: QItemSelection

--- a/src/napari_omero/widgets/main.py
+++ b/src/napari_omero/widgets/main.py
@@ -61,7 +61,7 @@ class OMEROWidget(QWidget):
         if not self.thumb_grid.selectedItems():
             return
         wrapper = self.thumb_grid.selectedItems()[0].wrapper
-        index: QModelIndex = self.model._wrapper_map.get(wrapper.getId())
+        index: QModelIndex = self.model._wrapper_map[wrapper.getId()]
         self.tree.selectionModel().select(
             index,
             QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows,

--- a/src/napari_omero/widgets/tree_model.py
+++ b/src/napari_omero/widgets/tree_model.py
@@ -71,7 +71,9 @@ class OMEROTreeModel(QStandardItemModel):
             return
 
         for item in projects:
-            for dataset in list(item.wrapper.listChildren()):
+            for dataset in list(self.gateway.conn.getObjects(
+                    "Dataset", opts={'project': item.wrapper.id,
+                                     'order_by': 'obj.name'})):
                 dchild = OMEROTreeItem(dataset)
                 item.appendRow(dchild)
                 self._wrapper_map[dataset.getId()] = self.indexFromItem(dchild)

--- a/src/napari_omero/widgets/tree_model.py
+++ b/src/napari_omero/widgets/tree_model.py
@@ -58,7 +58,9 @@ class OMEROTreeModel(QStandardItemModel):
 
         root = self.invisibleRootItem()
         projects = []
-        for project in list(self.gateway.conn.listProjects()):
+
+        for project in list(self.gateway.conn.getObjects(
+                            "Project", opts={'order_by': 'obj.name'})):
             item = OMEROTreeItem(project)
             root.appendRow(item)
             projects.append(item)

--- a/src/napari_omero/widgets/tree_model.py
+++ b/src/napari_omero/widgets/tree_model.py
@@ -84,7 +84,9 @@ class OMEROTreeModel(QStandardItemModel):
                 yield
                 if not self.gateway.isConnected():
                     return
-                for image in list(dataset.listChildren()):
+                for image in list(self.gateway.conn.getObjects(
+                        "Image", opts={'dataset': dataset.id,
+                                       'order_by': 'obj.name'})):
                     ichild = OMEROTreeItem(image)
                     dchild.appendRow(ichild)
                     self._wrapper_map[image.getId()] = self.indexFromItem(

--- a/src/napari_omero/widgets/tree_model.py
+++ b/src/napari_omero/widgets/tree_model.py
@@ -6,7 +6,7 @@ from omero.gateway import (
 from qtpy.QtCore import QModelIndex
 from qtpy.QtGui import QStandardItem, QStandardItemModel
 from .gateway import QGateWay
-from typing import Dict
+from typing import Dict, Optional
 
 
 class OMEROTreeItem(QStandardItem):
@@ -14,30 +14,48 @@ class OMEROTreeItem(QStandardItem):
         super().__init__()
         self.wrapper = wrapper
         self.setData(wrapper)
-        # self._has_fetched = False
-        self._childCount = None
-        if self.hasChildren():
-            self.setText(f"{self.wrapper.getName()} ({self.numChildren()})")
+        self._has_fetched = False
+        if self.child_type:
+            self.setText(f"{self.wrapper.getName()} ({self.n_children})")
         else:
             self.setText(f"{self.wrapper.getName()}")
 
-    # def canFetchMore(self) -> bool:
-    #     if self._has_fetched or not self.hasChildren():
-    #         return False
-    #     return self.wrapper.countChildren() > 0
+    def canFetchMore(self) -> bool:
+        return not self._has_fetched and self.hasChildren()
 
-    # def fetchChildren(self):
-    #     for child in self.wrapper.listChildren():
-    #         self.appendRow(OMEROTreeItem(child))
-    #     self._has_fetched = True
+    def yieldChildren(self):
+        yield from self.wrapper._conn.getObjects(
+            self.child_type,
+            opts={
+                self.wrapper_type.lower(): self.wrapper.id,
+                'order_by': 'obj.name',
+            },
+        )
 
-    def hasChildren(self):
-        return bool(self.wrapper.CHILD_WRAPPER_CLASS)
+    def hasChildren(self) -> bool:
+        return bool(self.child_type and self.n_children > 0)
 
-    def numChildren(self) -> int:
-        if self._childCount is None:
-            self._childCount = self.wrapper.countChildren()
-        return self._childCount
+    @property
+    def child_type(self) -> Optional[str]:
+        kls = self.wrapper.CHILD_WRAPPER_CLASS or ''
+        kls = kls if isinstance(kls, str) else kls.__name__
+        return kls.lstrip("_").replace("Wrapper", "") if kls else None
+
+    @property
+    def wrapper_type(self) -> str:
+        return self.wrapper.OMERO_CLASS
+
+    @property
+    def parent_type(self) -> Optional[str]:
+        kls = self.wrapper.PARENT_WRAPPER_CLASS or ''
+        kls = kls if isinstance(kls, str) else kls.__name__
+        return kls.lstrip("_").replace("Wrapper", "") if kls else None
+
+    @property
+    def n_children(self) -> int:
+        if not hasattr(self, '_n_children'):
+            self._n_children = self.wrapper.countChildren()
+        return self._n_children
 
     def isDataset(self) -> bool:
         return isinstance(self.wrapper, _DatasetWrapper)
@@ -50,61 +68,43 @@ class OMEROTreeModel(QStandardItemModel):
     def __init__(self, gateway: QGateWay, parent=None):
         super().__init__(parent)
         self.gateway = gateway
+        root = self.invisibleRootItem()
+        root.appendRow(QStandardItem('loading...'))
         self.gateway.connected.connect(
-            lambda g: self.gateway._submit(self._populate_tree)
+            lambda g: self.gateway._submit(
+                self._get_projects, _connect={'returned': self._add_projects}
+            )
         )
         self._wrapper_map: Dict[BlitzObjectWrapper, QModelIndex] = {}
 
-    def _populate_tree(self):
-        if not self.gateway.isConnected():
-            return
+    def _get_projects(self):
+        return self.gateway.getObjects(
+            "Project", opts={'order_by': 'obj.name'}
+        )
 
+    def _add_projects(self, projects):
         root = self.invisibleRootItem()
-        projects = []
-
-        for project in list(self.gateway.conn.getObjects(
-                            "Project", opts={'order_by': 'obj.name'})):
+        root.removeRow(0)
+        for project in projects:
             item = OMEROTreeItem(project)
             root.appendRow(item)
-            projects.append(item)
             self._wrapper_map[project.getId()] = self.indexFromItem(item)
-            yield
 
-        if not self.gateway.isConnected():
-            return
+    def canFetchMore(self, index: QModelIndex) -> bool:
+        item = self.itemFromIndex(index)
+        return bool(item and item.canFetchMore())
 
-        for item in projects:
-            for dataset in list(self.gateway.conn.getObjects(
-                    "Dataset", opts={'project': item.wrapper.id,
-                                     'order_by': 'obj.name'})):
-                dchild = OMEROTreeItem(dataset)
-                item.appendRow(dchild)
-                self._wrapper_map[dataset.getId()] = self.indexFromItem(dchild)
-
-                yield
-                if not self.gateway.isConnected():
-                    return
-                for image in list(self.gateway.conn.getObjects(
-                        "Image", opts={'dataset': dataset.id,
-                                       'order_by': 'obj.name'})):
-                    ichild = OMEROTreeItem(image)
-                    dchild.appendRow(ichild)
-                    self._wrapper_map[image.getId()] = self.indexFromItem(
-                        ichild
-                    )
-                    yield
-
-    # def canFetchMore(self, index: QModelIndex) -> bool:
-    #     item = self.itemFromIndex(index)
-    #     return bool(item and item.canFetchMore())
-
-    # def fetchMore(self, index: QModelIndex) -> None:
-    #     self.itemFromIndex(index).fetchChildren()
+    def fetchMore(self, index: QModelIndex) -> None:
+        item = self.itemFromIndex(index)
+        for c in item.yieldChildren():
+            item.appendRow(OMEROTreeItem(c))
+            self._wrapper_map[c.getId()] = self.indexFromItem(item)
+        item._has_fetched = True
 
     def hasChildren(self, index: QModelIndex) -> bool:
         item = self.itemFromIndex(index)
         if item is not None:
-            return item.hasChildren() and item.numChildren() > 0
+            return item.hasChildren() and item.n_children > 0
         return True
 
     def itemFromIndex(self, index: QModelIndex) -> OMEROTreeItem:

--- a/src/napari_omero/widgets/tree_model.py
+++ b/src/napari_omero/widgets/tree_model.py
@@ -15,6 +15,7 @@ class OMEROTreeItem(QStandardItem):
         self.wrapper = wrapper
         self.setData(wrapper)
         # self._has_fetched = False
+        self._childCount = None
         if self.hasChildren():
             self.setText(f"{self.wrapper.getName()} ({self.numChildren()})")
         else:
@@ -34,7 +35,9 @@ class OMEROTreeItem(QStandardItem):
         return bool(self.wrapper.CHILD_WRAPPER_CLASS)
 
     def numChildren(self) -> int:
-        return self.wrapper.countChildren()
+        if self._childCount is None:
+            self._childCount = self.wrapper.countChildren()
+        return self._childCount
 
     def isDataset(self) -> bool:
         return isinstance(self.wrapper, _DatasetWrapper)


### PR DESCRIPTION
Fixes a couple of issues from #9

 - No filtering by default group or user
 - Alphabetical ordering
 - Also caches `childCount` so we don't have to request this from the server multiple times.

To test:

```
$ omero login
# idr.openmicroscopy.org, public, public
$ napari_omero
```

The biggest issue now is that we try to load the whole depth of the tree up-front, instead of waiting for the user to expand each node.
This means that with IDR, you are loading *forever* and never reach the whole tree. But the top of the tree loads OK:

![Screenshot 2020-06-25 at 16 26 30](https://user-images.githubusercontent.com/900055/85750312-7e4c4780-b701-11ea-9a64-c966868b2472.png)
