### PR TITLE
load_image_wrapper returns 5D data with channel_axis:1

### DIFF
--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -7,7 +7,7 @@ from vispy.color import Colormap
 
 from napari.types import LayerData
 from omero.cli import ProxyStringType
-from omero.gateway import BlitzGateway, ImageWrapper, ChannelWrapper
+from omero.gateway import BlitzGateway, ImageWrapper
 from omero.model import IObject
 
 from ..utils import parse_omero_url, timer, lookup_obj, PIXEL_TYPES


### PR DESCRIPTION
When loading OMERO image, instead of looping through Channels, getting metadata and lazy data for each in turn,
we now get the **5D** data (regardless of whether this is a multi-Z or multi-T image) and a single dict with `channel_axis:1`

This means that the data dimensions don't change and are consistent with the ome-zarr spec. Shape is `(t, c, z, y, x)`.