### PR TITLE
Dont set z scale

### DIFF
--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -92,11 +92,11 @@ def get_omero_metadata(image: ImageWrapper) -> Dict:
     names = [ch.getLabel() for ch in channels]
 
     scale = None
-    if image.getSizeZ() > 1:
-        size_x = image.getPixelSizeX()
-        size_z = image.getPixelSizeZ()
-        if size_x is not None and size_z is not None:
-            scale = [1, size_z / size_x, 1, 1]
+    # if image.getSizeZ() > 1:
+    #     size_x = image.getPixelSizeX()
+    #     size_z = image.getPixelSizeZ()
+    #     if size_x is not None and size_z is not None:
+    #         scale = [1, size_z / size_x, 1, 1]
 
     return {
         'channel_axis': 1,

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -92,6 +92,8 @@ def get_omero_metadata(image: ImageWrapper) -> Dict:
     names = [ch.getLabel() for ch in channels]
 
     scale = None
+    # Setting z-scale causes issues with Z-slider.
+    # See https://github.com/tlambert03/napari-omero/pull/15
     # if image.getSizeZ() > 1:
     #     size_x = image.getPixelSizeX()
     #     size_z = image.getPixelSizeZ()


### PR DESCRIPTION
This comments-out the setting of Z-scale, which I find causes various issues (testing with
`napari==0.3.5`).

Testing with a Z-stack image of `size_Z = 50`, with pixel size `X: 0.633` and `Z: 0.2` microns. Available at
https://downloads.openmicroscopy.org/images/DV/elena/P-TRE/P-TRE_21_R3D_D3D.dv

Without this PR, we set `scale = [1, 3.0161362196625654, 1, 1]`, which causes the Z-slider to report an index of Z-1.
See first screenshot:
 - The max Z index is 48 (should be 49).
 - The current index in the screenshot is showing as 0, when the slider has been incremented 1 place from the left. (left-most position also shows index of 0).
 - `get_plane()` is correctly loading Z-index of 1 from OMERO. 

<img width="736" alt="Screenshot 2020-06-28 at 16 07 12" src="https://user-images.githubusercontent.com/900055/85957786-4145b680-b988-11ea-994c-2575f2231a50.png">

 - If I then click to add a Shapes layer, the Z-index slider shows that I am now on index ```3 / 149``` (without changing the Z-index) and Shapes drawn on this layer have coordinates of Z-index: 3. The current ```save_rois()``` code for saving ROIs back to OMERO will therefore save these on `Z:3` (instead of `Z:1`).

<img width="761" alt="Screenshot 2020-06-28 at 21 55 46" src="https://user-images.githubusercontent.com/900055/85958136-085b1100-b98b-11ea-85a9-491693e552e2.png">

If I try a different Z-scaling, manually setting the scale to `[1, 2.0, 1, 1]` (for testing), the initial Z-slider shows a max of `49` (correct).
When I switch to Shapes layer, I see a max-Z index of `99`.
As I increment the Z-slider through the 99 indices, I see an unpredictable mapping between Z-slider and the Z-index of planes loaded from OMERO, with some planes being displayed for 3 Z-indices and some for only 1 (instead of 2 each as you might expect):

 - slider: 0, plane: 0
 - slider: 1, plane: 0
 - slider: 2, plane: 1
 - slider: 3, plane: 2
 - slider: 4, plane: 2
 - slider: 5, plane: 2
 - slider: 6, plane: 3
 - slider: 7, plane: 4
 - slider: 8, plane: 4
 - slider: 9, plane: 4
 - slider: 10, plane: 5

So, when saving a Shape back to OMERO, it's hard to map Z-coordinates from napari to a plane in OMERO (without a look-up table as above).
