### PR TITLE
save_rois() saves masks to OMERO

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,5 +7,6 @@ dependencies:
   - python=3.7
   - pip
   - omero-py=5.6.2
+  - omero-rois
   - pip:
     - .[dev]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ python_requires = >=3.6,<3.8
 install_requires =
     napari[all]>=0.3.0
     omero-py
+    omero-rois
 
 
 [options.entry_points]

--- a/src/napari_omero/plugins/masks.py
+++ b/src/napari_omero/plugins/masks.py
@@ -1,10 +1,7 @@
 import numpy as np
-import math
-import struct
 from random import randint
 
-from omero.model import MaskI, RoiI
-from omero.rtypes import rint, rdouble
+from omero.model import RoiI
 from omero_rois import mask_from_binary_image
 
 

--- a/src/napari_omero/plugins/masks.py
+++ b/src/napari_omero/plugins/masks.py
@@ -1,12 +1,10 @@
 import numpy as np
 import math
 import struct
-import zarr
 from random import randint
 
 from omero.model import MaskI, RoiI
 from omero.rtypes import rint, rdouble
-from omero.gateway import BlitzGateway
 
 
 def numpy_to_bytearray(numpy_mask):

--- a/src/napari_omero/plugins/masks.py
+++ b/src/napari_omero/plugins/masks.py
@@ -5,50 +5,7 @@ from random import randint
 
 from omero.model import MaskI, RoiI
 from omero.rtypes import rint, rdouble
-
-
-def numpy_to_bytearray(numpy_mask):
-
-    # Set correct number of bytes per value
-    mask_array = numpy_mask.astype(np.uint8)
-    # Convert the mask to bytes
-    mask_bytes = mask_array.tostring()
-    # Pack the bytes to a bit mask
-    divider = 8
-    format_string = "B"  # Unsigned char
-    byte_factor = 1
-    steps = math.ceil(len(mask_bytes) / divider)
-    mask = []
-    for i in range(int(steps)):
-        binary = mask_bytes[i * divider : (i + 1) * divider]
-        format = f'{int(byte_factor * len(binary))}{ format_string }'
-        binary = struct.unpack(format, binary)
-        s = ""
-        for bit in binary:
-            s += str(bit)
-        mask.append(int(s, 2))
-    return bytearray(mask)
-
-
-def crop_plane_to_mask(bool_plane):
-
-    plane_h, plane_w = bool_plane.shape
-    # list of booleans
-    cols = np.any(bool_plane, axis=0)
-    rows = np.any(bool_plane, axis=1)
-
-    # find bounding box
-    x = np.argmax(cols)  # 0
-    y = np.argmax(rows)  # 1
-    cols_reverse = cols[::-1]  # copy with 'step' -1
-    rows_reverse = rows[::-1]
-    x2 = plane_w - np.argmax(cols_reverse)
-    y2 = plane_h - np.argmax(rows_reverse)
-    mask_w = x2 - x
-    mask_h = y2 - y
-
-    cropped = bool_plane[y:y2, x:x2]
-    return (x, y, mask_w, mask_h, cropped)
+from omero_rois import mask_from_binary_image
 
 
 def create_roi(image, shapes):
@@ -91,20 +48,8 @@ def save_label(bool_4d, image):
         for t in range(0, size_t):
             masks_2d = bool_4d[t][z]
             if np.any(masks_2d.flatten()):
-                print('create mask shape, z:', z)
-                x, y, w, h, cropped = crop_plane_to_mask(masks_2d)
-                packed_bypes = numpy_to_bytearray(cropped)
-                mask = MaskI()
-                mask.setTheZ(rint(z))
-                mask.setTheT(rint(t))
-                mask.setX(rdouble(x))
-                mask.setY(rdouble(y))
-                mask.setWidth(rdouble(w))
-                mask.setHeight(rdouble(h))
                 rgba = [randint(0, 255), randint(0, 255), randint(0, 255), 255]
-                color = int.from_bytes(rgba, byteorder='big', signed=True)
-                mask.setFillColor(rint(color))
-                mask.setBytes(packed_bypes)
+                mask = mask_from_binary_image(masks_2d, rgba=rgba, z=z, t=t)
                 mask_shapes.append(mask)
 
     print(f'Creating ROI with {len(mask_shapes)} shapes')

--- a/src/napari_omero/plugins/masks.py
+++ b/src/napari_omero/plugins/masks.py
@@ -1,0 +1,113 @@
+import numpy as np
+import math
+import struct
+import zarr
+from random import randint
+
+from omero.model import MaskI, RoiI
+from omero.rtypes import rint, rdouble
+from omero.gateway import BlitzGateway
+
+
+def numpy_to_bytearray(numpy_mask):
+
+    # Set correct number of bytes per value
+    mask_array = numpy_mask.astype(np.uint8)
+    # Convert the mask to bytes
+    mask_bytes = mask_array.tostring()
+    # Pack the bytes to a bit mask
+    divider = 8
+    format_string = "B"  # Unsigned char
+    byte_factor = 1
+    steps = math.ceil(len(mask_bytes) / divider)
+    mask = []
+    for i in range(int(steps)):
+        binary = mask_bytes[i * divider : (i + 1) * divider]
+        format = f'{int(byte_factor * len(binary))}{ format_string }'
+        binary = struct.unpack(format, binary)
+        s = ""
+        for bit in binary:
+            s += str(bit)
+        mask.append(int(s, 2))
+    return bytearray(mask)
+
+
+def crop_plane_to_mask(bool_plane):
+
+    plane_h, plane_w = bool_plane.shape
+    # list of booleans
+    cols = np.any(bool_plane, axis=0)
+    rows = np.any(bool_plane, axis=1)
+
+    # find bounding box
+    x = np.argmax(cols)  # 0
+    y = np.argmax(rows)  # 1
+    cols_reverse = cols[::-1]  # copy with 'step' -1
+    rows_reverse = rows[::-1]
+    x2 = plane_w - np.argmax(cols_reverse)
+    y2 = plane_h - np.argmax(rows_reverse)
+    mask_w = x2 - x
+    mask_h = y2 - y
+
+    cropped = bool_plane[y:y2, x:x2]
+    return (x, y, mask_w, mask_h, cropped)
+
+
+def create_roi(image, shapes):
+    updateService = image._conn.getUpdateService()
+    roi = RoiI()
+    # use the omero.model.ImageI that underlies the 'image' wrapper
+    roi.setImage(image._obj)
+    for shape in shapes:
+        roi.addShape(shape)
+    # Save the ROI (saves any linked shapes too)
+    return updateService.saveAndReturnObject(roi)
+
+
+def save_labels(masks_4d, image):
+    """
+    Saves masks from a 5D image (no C dimension)
+
+    Each non-zero value in the labels data
+    is used to create an ROI in OMERO with a
+    Shape Mask created for each Z/T plane of
+    the the mask.
+    """
+    print('masks_4d.shape', masks_4d.shape)
+    print('min, max', masks_4d.min(), masks_4d.max())
+
+    # for each label value, check if we have any masks
+    for v in range(1, masks_4d.max() + 1):
+        hits = masks_4d.flatten() == v
+        if np.any(hits):
+            save_label(masks_4d == v, image)
+
+
+def save_label(bool_4d, image):
+
+    size_t = bool_4d.shape[0]
+    size_z = bool_4d.shape[1]
+    # Create an ROI with a shape for each Z/T that has some mask
+    mask_shapes = []
+    for z in range(0, size_z):
+        for t in range(0, size_t):
+            masks_2d = bool_4d[t][z]
+            if np.any(masks_2d.flatten()):
+                print('create mask shape, z:', z)
+                x, y, w, h, cropped = crop_plane_to_mask(masks_2d)
+                packed_bypes = numpy_to_bytearray(cropped)
+                mask = MaskI()
+                mask.setTheZ(rint(z))
+                mask.setTheT(rint(t))
+                mask.setX(rdouble(x))
+                mask.setY(rdouble(y))
+                mask.setWidth(rdouble(w))
+                mask.setHeight(rdouble(h))
+                rgba = [randint(0, 255), randint(0, 255), randint(0, 255), 255]
+                color = int.from_bytes(rgba, byteorder='big', signed=True)
+                mask.setFillColor(rint(color))
+                mask.setBytes(packed_bypes)
+                mask_shapes.append(mask)
+
+    print(f'Creating ROI with {len(mask_shapes)} shapes')
+    create_roi(image, mask_shapes)

--- a/src/napari_omero/plugins/masks.py
+++ b/src/napari_omero/plugins/masks.py
@@ -28,9 +28,6 @@ def save_labels(masks_4d, image):
     Shape Mask created for each Z/T plane of
     the the mask.
     """
-    print('masks_4d.shape', masks_4d.shape)
-    print('min, max', masks_4d.min(), masks_4d.max())
-
     # for each label value, check if we have any masks
     for v in range(1, masks_4d.max() + 1):
         hits = masks_4d.flatten() == v
@@ -39,7 +36,6 @@ def save_labels(masks_4d, image):
 
 
 def save_label(bool_4d, image):
-
     size_t = bool_4d.shape[0]
     size_z = bool_4d.shape[1]
     # Create an ROI with a shape for each Z/T that has some mask

--- a/src/napari_omero/plugins/masks.py
+++ b/src/napari_omero/plugins/masks.py
@@ -24,7 +24,7 @@ def save_labels(layer, image: ImageWrapper) -> List[RoiI]:
     Each non-zero value in the labels data
     is used to create an ROI in OMERO with a
     Shape Mask created for each Z/T plane of
-    the the mask.
+    the mask.
     """
     # for each label value, check if we have any masks
     masks_4d = layer.data

--- a/src/napari_omero/plugins/masks.py
+++ b/src/napari_omero/plugins/masks.py
@@ -1,11 +1,13 @@
+from typing import List
 import numpy as np
 from random import randint
 
+from omero.gateway import ImageWrapper
 from omero.model import RoiI
 from omero_rois import mask_from_binary_image
 
 
-def create_roi(image, shapes):
+def create_roi(image: ImageWrapper, shapes) -> RoiI:
     updateService = image._conn.getUpdateService()
     roi = RoiI()
     # use the omero.model.ImageI that underlies the 'image' wrapper
@@ -16,7 +18,7 @@ def create_roi(image, shapes):
     return updateService.saveAndReturnObject(roi)
 
 
-def save_labels(masks_4d, image):
+def save_labels(masks_4d: np.ndarray, image: ImageWrapper) -> List[RoiI]:
     """
     Saves masks from a 5D image (no C dimension)
 
@@ -26,13 +28,16 @@ def save_labels(masks_4d, image):
     the the mask.
     """
     # for each label value, check if we have any masks
+    rois = []
     for v in range(1, masks_4d.max() + 1):
         hits = masks_4d.flatten() == v
         if np.any(hits):
-            save_label(masks_4d == v, image)
+            rois.append(save_label(masks_4d == v, image))
+    return rois
 
 
-def save_label(bool_4d, image):
+def save_label(bool_4d: np.ndarray, image: ImageWrapper) -> RoiI:
+    """Turns a boolean array of shape (t, z, y, x) into OMERO Roi"""
     size_t = bool_4d.shape[0]
     size_z = bool_4d.shape[1]
     # Create an ROI with a shape for each Z/T that has some mask
@@ -46,4 +51,4 @@ def save_label(bool_4d, image):
                 mask_shapes.append(mask)
 
     print(f'Creating ROI with {len(mask_shapes)} shapes')
-    create_roi(image, mask_shapes)
+    return create_roi(image, mask_shapes)

--- a/src/napari_omero/plugins/omero.py
+++ b/src/napari_omero/plugins/omero.py
@@ -208,7 +208,7 @@ def save_rois(viewer, image):
                     print("Created ROI: %s" % roi.id.val)
         elif type(layer) == labels_layer:
             print("Saving Labels...")
-            save_labels(layer.data, image)
+            save_labels(layer, image)
 
 
 def get_x(coordinate):

--- a/src/napari_omero/plugins/omero.py
+++ b/src/napari_omero/plugins/omero.py
@@ -24,6 +24,7 @@ from omero.model import (
 )
 from omero.rtypes import rdouble, rint, rstring
 
+from .masks import save_labels
 from ..utils import lookup_obj, obj_to_proxy_string
 
 HELP = "Connect OMERO to the napari image viewer"
@@ -206,7 +207,8 @@ def save_rois(viewer, image):
                     roi = create_roi(conn, image.id, [shape])
                     print("Created ROI: %s" % roi.id.val)
         elif type(layer) == labels_layer:
-            print("Saving Labels not supported")
+            print("Saving Labels...")
+            save_labels(layer.data, image)
 
 
 def get_x(coordinate):


### PR DESCRIPTION
Some initial code to save napari labels to OMERO as masks.
Work in progress (needs linting, mypi types etc).
cc @joshmoore 

To test:
We use the ```omero napari``` command so that the "Save ROIs" button is displayed.
```
$ omero napari view Image:1
```
Draw some labels on the image.
Click "Save ROIs".
Each label should be saved as a new ROI with Mask shape(s)

<img width="801" alt="Screenshot 2020-06-29 at 23 53 14" src="https://user-images.githubusercontent.com/900055/86064201-690a4c80-ba64-11ea-939b-a5d01480a780.png">

<img width="1022" alt="Screenshot 2020-06-29 at 23 54 08" src="https://user-images.githubusercontent.com/900055/86064257-850dee00-ba64-11ea-9d2c-13ca1fd74330.png">
