### PR TITLE
Omero plugin only handles path with Image:ID

### DIFF
--- a/src/napari_omero/utils.py
+++ b/src/napari_omero/utils.py
@@ -62,6 +62,10 @@ omero_url_pattern = re.compile(
     r"/\?show=(?P<type>[a-z]+)-(?P<id>[0-9]+)"
 )
 
+omero_object_pattern = re.compile(
+    r"(?P<type>(Image|Dataset|Project)):(?P<id>[0-9]+)"
+)
+
 
 def parse_omero_url(url: str) -> Optional[Dict[str, str]]:
     match = omero_url_pattern.search(url)
@@ -69,6 +73,10 @@ def parse_omero_url(url: str) -> Optional[Dict[str, str]]:
 
 
 def get_proxy_obj(path: str) -> Optional[IObject]:
+    """If path ends with e.g. Image:ID return proxy obj"""
+    match = omero_object_pattern.search(path)
+    if match is None:
+        return None
     for proxy_type in PROXIES:
         try:
             return proxy_type(path)


### PR DESCRIPTION
As reported https://github.com/tlambert03/napari-omero/pull/17#issuecomment-651589069 by @joshmoore 

This makes the omero plugin more specific about the paths that it tries to handle.
Only handle paths that match `Image|Dataset|Project:ID`.

Maybe this should only be `Image:ID` since we don't yet handle Dataset or Project.

To test:
 - Open something that is not handled by other plugins, e.g regular zarr (not ome-zarr) 
```napari 1.zarr/masks/0/```  See https://github.com/tlambert03/napari-omero/pull/17#issuecomment-651588577
 - Shouldn't see any error like:
```
08:59:04 ERROR PluginError: Error in plugin 'omero', hook 'napari_get_reader'
  Cause was: NameError('No such Image: object #0 (::omero::RLong)\n{\n    _val = 0\n}',)
```