### PR TITLE
Fix napari-omero command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To launch napari with the OMERO browser added, [install](#installation) this
 package and run:
 
 ```bash
-napari_omero
+napari-omero
 ```
 
 The OMERO browser widget can also be manually added to the napari viewer:


### PR DESCRIPTION
While testing for https://github.com/tlambert03/napari-omero/issues/36 on a new install, I noticed that `$ napari_omero` command didn't work and I needed `$ napari-omero`.

Don't know if something changed or has this always been wrong?