### PR TITLE
Avoid double loading

### DIFF
--- a/src/napari_omero/widgets/main.py
+++ b/src/napari_omero/widgets/main.py
@@ -67,6 +67,9 @@ class OMEROWidget(QWidget):
         wrapper = self.thumb_grid.selectedItems()[0].wrapper
         index: QModelIndex = self.model._wrapper_map.get(wrapper.getId())
         if index:
+            # avoid loading the same image twice
+            if self.tree.selectionModel().isSelected(index):
+                return
             self.tree.selectionModel().select(
                 index,
                 QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows,
@@ -101,6 +104,9 @@ class OMEROWidget(QWidget):
         self.thumb_grid.set_item(item)
 
         if item.isImage():
+            # avoid loading the same image twice
+            if self.thumb_grid.currentItem() and self.thumb_grid.currentItem().wrapper == item.wrapper:
+                return
             QCoreApplication.processEvents()
             self.load_image(item.wrapper)
 

--- a/src/napari_omero/widgets/main.py
+++ b/src/napari_omero/widgets/main.py
@@ -67,9 +67,6 @@ class OMEROWidget(QWidget):
         wrapper = self.thumb_grid.selectedItems()[0].wrapper
         index: QModelIndex = self.model._wrapper_map.get(wrapper.getId())
         if index:
-            # avoid loading the same image twice
-            if self.tree.selectionModel().isSelected(index):
-                return
             self.tree.selectionModel().select(
                 index,
                 QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows,


### PR DESCRIPTION
Fixes https://github.com/tlambert03/napari-omero/issues/61. Essentially, the treeview and the thumbgrid both load an image upon clicking an item, but selecting an item in the treeview autoselects the respective item in the thumbgrid -> double selection.

This PR basically checks whether the two are in sync and triggers the loading only once.