### PR TITLE
Bugfix: Prevent double loading by having the tree model be a single source of truth

### DIFF
--- a/src/napari_omero/widgets/main.py
+++ b/src/napari_omero/widgets/main.py
@@ -101,7 +101,6 @@ class OMEROWidget(QWidget):
                 index,
                 QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows,
             )
-        self.load_image(wrapper)
 
     def _setup_tree(self):
         """Set up QTreeView with a fresh tree model."""
@@ -191,12 +190,6 @@ class OMEROWidget(QWidget):
         self.thumb_grid.set_item(item)
 
         if item.isImage():
-            # avoid loading the same image twice
-            if (
-                self.thumb_grid.currentItem()
-                and self.thumb_grid.currentItem().wrapper == item.wrapper
-            ):
-                return
             QCoreApplication.processEvents()
             self.load_image(item.wrapper)
 


### PR DESCRIPTION
Closes: https://github.com/tlambert03/napari-omero/issues/73

My understanding is that expanding items was triggering the `fetch` methods from the model, adding items to the tree. But it doesn't involve selection. And without selection, the thumbnails are not updated and become out of sync with the tree model.
Then, when you click on an item in the tree it sets the item in the model and the thumbnail grid. Both involve interactions with the Blitz gateway and I think this was creating some sort of race condition leading to the seg faults I observe.
Additionally, setting the thumbnail selection triggered `load_image`, as did selecting the item in the list.
I think the solution from #61 doesn't work anymore because the image loading from the thumbnail happens second, after the tree item selection -- because when expanding there is no thumbnail (see #74).

So in this PR, I remove the `load_image` from the thumbnail selection callback, so only tree view item selection loads images. This makes the tree model the source of truth, regardless of the thumbnail state.
Then we can remove the code from #64 because there is only one way to actually load images -- via the tree model selection. The thumbnail selection is just a proxy for setting the selected tree item.

Note: this does not address the fact that as of #46 images are not removed when new images are loaded.
I will make a separate PR for that.
Likewise, having expanding trigger selection (#74) has value, because it triggers loading of thumbnails when the user expands the tree. I think this is a worthwhile enhancement of it's own.
