### PR TITLE
ENH: Check OMERO color versus napari colormaps and use them if they exist

### DIFF
--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -80,12 +80,24 @@ def get_omero_metadata(image: ImageWrapper) -> dict:
     for ch in channels:
         # use current rendering settings from OMERO
         color = ch.getColor()
-        # ensure white and black always work properly
+        # ensure basics always work properly
         # even for napari <0.4.19
         if color.getHtml() == "000000":
             colors.append(ensure_colormap("gray_r"))
         if color.getHtml() == "FFFFFF":
             colors.append(ensure_colormap("gray"))
+        if color.getHtml() == "FF0000":
+            colors.append(ensure_colormap("red"))
+        if color.getHtml() == "00FF00":
+            colors.append(ensure_colormap("green"))
+        if color.getHtml() == "0000FF":
+            colors.append(ensure_colormap("blue"))
+        if color.getHtml() == "FF00FF":
+            colors.append(ensure_colormap("magenta"))
+        if color.getHtml() == "00FFFF":
+            colors.append(ensure_colormap("cyan"))
+        if color.getHtml() == "FFFF00":
+            colors.append(ensure_colormap("yellow"))
         else:
             try:
                 # requires 0.4.19 or later

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -3,7 +3,7 @@ from typing import Optional
 import dask.array as da
 from dask.delayed import delayed
 from napari.types import LayerData
-from vispy.color import Colormap
+from napari.utils.colormaps import ensure_colormap
 
 from napari_omero.utils import PIXEL_TYPES, lookup_obj, parse_omero_url, timer
 from napari_omero.widgets import QGateWay
@@ -78,9 +78,10 @@ def get_omero_metadata(image: ImageWrapper) -> dict:
     colors = []
     for ch in channels:
         # use current rendering settings from OMERO
-        color = ch.getColor().getRGB()
-        color = [r / 256 for r in color]
-        colors.append(Colormap([[0, 0, 0], color]))
+        color = ch.getColor().getHtml()
+        # if the colormap exists in napari, use it
+        # otherwise, create a custom colormap
+        colors.append(ensure_colormap("#" + color))
 
     contrast_limits = [[ch.getWindowStart(), ch.getWindowEnd()] for ch in channels]
 

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -79,9 +79,15 @@ def get_omero_metadata(image: ImageWrapper) -> dict:
     for ch in channels:
         # use current rendering settings from OMERO
         color = ch.getColor().getHtml()
-        # if the colormap exists in napari, use it
-        # otherwise, create a custom colormap
-        colors.append(ensure_colormap("#" + color))
+        # work around a napari bug https://github.com/napari/napari/issues/7504
+        if color == "000000":
+            colors.append(ensure_colormap("gray_r"))
+        if color == "FFFFFF":
+            colors.append(ensure_colormap("gray"))
+        else:
+            # if the colormap exists in napari, use it
+            # otherwise, create a custom colormap
+            colors.append(ensure_colormap("#" + color))
 
     contrast_limits = [[ch.getWindowStart(), ch.getWindowEnd()] for ch in channels]
 

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -72,6 +72,18 @@ def load_image_wrapper(image: ImageWrapper) -> list[LayerData]:
     return [(data, meta)]
 
 
+BASIC_COLORMAPS = {
+    "000000": "gray_r",
+    "FFFFFF": "gray",
+    "FF0000": "red",
+    "00FF00": "green",
+    "0000FF": "blue",
+    "FF00FF": "magenta",
+    "00FFFF": "cyan",
+    "FFFF00": "yellow",
+}
+
+
 def get_omero_metadata(image: ImageWrapper) -> dict:
     """Get metadata from OMERO as a Dict to pass to napari."""
     channels = image.getChannels()
@@ -80,24 +92,9 @@ def get_omero_metadata(image: ImageWrapper) -> dict:
     for ch in channels:
         # use current rendering settings from OMERO
         color = ch.getColor()
-        # ensure basics always work properly
-        # even for napari <0.4.19
-        if color.getHtml() == "000000":
-            colors.append(ensure_colormap("gray_r"))
-        if color.getHtml() == "FFFFFF":
-            colors.append(ensure_colormap("gray"))
-        if color.getHtml() == "FF0000":
-            colors.append(ensure_colormap("red"))
-        if color.getHtml() == "00FF00":
-            colors.append(ensure_colormap("green"))
-        if color.getHtml() == "0000FF":
-            colors.append(ensure_colormap("blue"))
-        if color.getHtml() == "FF00FF":
-            colors.append(ensure_colormap("magenta"))
-        if color.getHtml() == "00FFFF":
-            colors.append(ensure_colormap("cyan"))
-        if color.getHtml() == "FFFF00":
-            colors.append(ensure_colormap("yellow"))
+        # ensure the basics work regardless of napari version
+        if color.getHtml() in BASIC_COLORMAPS:
+            colors.append(ensure_colormap(BASIC_COLORMAPS[color.getHtml()]))
         else:
             try:
                 # requires 0.4.19 or later


### PR DESCRIPTION
Closes: https://github.com/tlambert03/napari-omero/issues/77

Currently when an image is loaded the color from OMERO is used to create a new colormap every time.
In this PR I used a napari utility function that checks whether a colormap exists for the color and use that, else make a new colormap with the hex code of the color.
This works quite well for the images I've tested that use CYM, RGB. Nice QoL improvement.
I did run into an issue with White (which also happens for Black) where napari incorrectly doesn't realize it has that colormap (gray and gray_r) see https://github.com/napari/napari/issues/7504. I've put in a workaround.