### PR TITLE
Handle gateway timeout

### DIFF
--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -116,7 +116,7 @@ class QGateWay(QObject):
             # Attempt to create a socket connection to the server
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.settimeout(timeout)
-                s.connect((self._host, int(self._port  or 4064)))
+                s.connect((self._host, int(self._port or 4064)))
                 return True
         except (OSError, socket.timeout):
             return False

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -36,7 +36,7 @@ class QGateWay(QObject):
         self.worker: Optional[WorkerBase] = None
         self._next_worker: Optional[WorkerBase] = None
         self.worker_watchdog = None
-        self._connection_watchdog_timout = 5
+        self._connection_watchdog_timout = 3
 
     @property
     def conn(self):

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -101,6 +101,7 @@ class QGateWay(QObject):
             if not connected:
                 self.gateway.disconnected.emit()
                 self.conn_watchdog_worker = None
+                self.status.emit("Error: Connection timed out.")
                 return
             
             time.sleep(self._connection_watchdog_timout)

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -95,11 +95,12 @@ class QGateWay(QObject):
         return self.store.get_current()
 
     def _connection_watchdog(self):
+        # Function to be executed in thread to check connection status regularly
         import time
         while True:
             connected = self._check_connection(timeout=self._connection_watchdog_timout)
             if not connected:
-                self.gateway.disconnected.emit()
+                self.disconnected.emit()
                 self.conn_watchdog_worker = None
                 self.status.emit("Error: Connection timed out.")
                 return

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -172,6 +172,7 @@ class QGateWay(QObject):
             self.error.emit(e)
 
     def _on_new_session(self, session: SessionStats):
+        from napari.qt.threading import create_worker
         client = session[0]
         if not client:
             return
@@ -182,6 +183,9 @@ class QGateWay(QObject):
 
         self.connected.emit(self.conn)
         self.status.emit("")
+
+        worker_watchdog = create_worker(self._connection_watchdog)
+        worker_watchdog.start()
         return self.conn
 
     def getObjects(

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -96,8 +96,8 @@ class QGateWay(QObject):
 
     def _connection_watchdog(self):
         # Function to be executed in thread to check connection status regularly
-        import time
         import socket
+        import time
 
         while True:
             try:

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -103,11 +103,14 @@ class QGateWay(QObject):
                 self.conn_watchdog_worker = None
                 return
 
-    def _check_connection(self, timeout: int = 5):
+    def _check_connection(self, timeout: int = 2):
+        # Function to check if a connection can be established to the server
         import socket
         try:
             # Attempt to create a socket connection to the server
-            with socket.create_connection(self.host, timeout=timeout) as sock:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(timeout)
+                s.connect((self._host, int(self._port)))
                 return True
         except (socket.timeout, socket.error):
             return False

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -116,7 +116,7 @@ class QGateWay(QObject):
             # Attempt to create a socket connection to the server
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.settimeout(timeout)
-                s.connect((self._host, int(self._port)))
+                s.connect((self._host, int(self._port  or 4064)))
                 return True
         except (OSError, socket.timeout):
             return False

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -34,7 +34,10 @@ class QGateWay(QObject):
         self.destroyed.connect(self.close)
         atexit.register(self.close)
         self.worker: Optional[WorkerBase] = None
+        self.conn_watchdog_worker: Optional[WorkerBase] = None
         self._next_worker: Optional[WorkerBase] = None
+
+        self.timeout_check_interval = 5  # how often to check for timeout
 
     @property
     def conn(self):
@@ -91,6 +94,18 @@ class QGateWay(QObject):
 
     def get_current(self) -> tuple[str, str, str, str]:
         return self.store.get_current()
+    
+    def _start_connection_watchdog(self):
+        """Start the connection watchdog worker."""
+        self.conn_watchdog_worker = self._submit(self._connection_watchdog)
+
+    def _connection_watchdog(self):
+        """Worker function to monitor the connection."""
+        while True:
+            if not self.isConnected():
+                self.disconnected.emit()
+                break
+            self.conn_watchdog_worker.sleep(self.timeout_check_interval)
 
     def _start_next_worker(self):
         if self._next_worker is not None:
@@ -162,6 +177,7 @@ class QGateWay(QObject):
 
         self.connected.emit(self.conn)
         self.status.emit("")
+        self._start_connection_watchdog()
         return self.conn
 
     def getObjects(
@@ -188,6 +204,7 @@ class NonCachedPixelsWrapper(PixelsWrapper):
         ps = self._conn.c.sf.createRawPixelsStore()
         ps.setPixelsId(self._obj.id.val, True, self._conn.SERVICE_OPTS)
         return ps
+    
 
 
 omero.gateway.PixelsWrapper = NonCachedPixelsWrapper

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -97,6 +97,7 @@ class QGateWay(QObject):
     def _connection_watchdog(self):
         # Function to be executed in thread to check connection status regularly
         import time
+
         while True:
             connected = self._check_connection(timeout=self._connection_watchdog_timout)
             if not connected:
@@ -104,19 +105,20 @@ class QGateWay(QObject):
                 self.conn_watchdog_worker = None
                 self.status.emit("Error: Connection timed out.")
                 return
-            
+
             time.sleep(self._connection_watchdog_timout)
 
     def _check_connection(self, timeout: int = 2):
         # Function to check if a connection can be established to the server
         import socket
+
         try:
             # Attempt to create a socket connection to the server
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.settimeout(timeout)
                 s.connect((self._host, int(self._port)))
                 return True
-        except (socket.timeout, socket.error):
+        except (OSError, socket.timeout):
             return False
 
     def _start_next_worker(self):
@@ -180,6 +182,7 @@ class QGateWay(QObject):
 
     def _on_new_session(self, session: SessionStats):
         from napari.qt.threading import create_worker
+
         client = session[0]
         if not client:
             return
@@ -219,7 +222,6 @@ class NonCachedPixelsWrapper(PixelsWrapper):
         ps = self._conn.c.sf.createRawPixelsStore()
         ps.setPixelsId(self._obj.id.val, True, self._conn.SERVICE_OPTS)
         return ps
-    
 
 
 omero.gateway.PixelsWrapper = NonCachedPixelsWrapper

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -102,6 +102,8 @@ class QGateWay(QObject):
                 self.gateway.disconnected.emit()
                 self.conn_watchdog_worker = None
                 return
+            
+            time.sleep(self._connection_watchdog_timout)
 
     def _check_connection(self, timeout: int = 2):
         # Function to check if a connection can be established to the server

--- a/src/napari_omero/widgets/gateway.py
+++ b/src/napari_omero/widgets/gateway.py
@@ -189,9 +189,10 @@ class QGateWay(QObject):
         self.connected.emit(self.conn)
         self.status.emit("")
 
-        self.worker_watchdog = create_worker(self._connection_watchdog)
-        self.worker_watchdog.yielded.connect(self._on_yield_connection_watchdog)
-        self.worker_watchdog.start()
+        if not self.worker_watchdog:
+            self.worker_watchdog = create_worker(self._connection_watchdog)
+            self.worker_watchdog.yielded.connect(self._on_yield_connection_watchdog)
+            self.worker_watchdog.start()
         return self.conn
 
     def getObjects(

--- a/src/napari_omero/widgets/main.py
+++ b/src/napari_omero/widgets/main.py
@@ -121,6 +121,10 @@ class OMEROWidget(QWidget):
         self.group_widget.hide()
         self.user_widget.hide()
 
+        if self.gateway.worker_watchdog:
+            self.gateway.worker_watchdog.quit()
+            self.gateway.worker_watchdog = None
+
         self._setup_tree()
 
     def _on_connect(self):

--- a/src/napari_omero/widgets/main.py
+++ b/src/napari_omero/widgets/main.py
@@ -83,6 +83,7 @@ class OMEROWidget(QWidget):
         self.splitter.addWidget(self.tree)
         self.splitter.addWidget(self.thumb_grid)
         self.gateway.connected.connect(self._on_connect)
+        self.gateway.disconnected.connect(self._on_disconnect)
         self.disconnect_button.clicked.connect(self._on_disconnect)
 
     @property


### PR DESCRIPTION
Fixes #71 

This pull request introduces a connection watchdog to the `QGateWay` class to monitor the connection status and handle disconnections more gracefully. Basically, the `socket` module is used to check whether a connection to `gateway._host` and `gateway._port` can be established. If it can't, the `disconnect` signal is emitted, triggering the built-in teardown of the treeview and displaying an error message.

Connection monitoring:

* [`src/napari_omero/widgets/gateway.py`](diffhunk://#diff-37dddf8857941f99100806af5557134fdbcaa82646967f414e7ab12b9524fe49R97-R121): Introduced a `_connection_watchdog` function to periodically check the connection status and emit a disconnect signal if the connection times out. Added a `_check_connection` helper function to attempt socket connections.
* [`src/napari_omero/widgets/gateway.py`](diffhunk://#diff-37dddf8857941f99100806af5557134fdbcaa82646967f414e7ab12b9524fe49R39-R40): Added a `_connection_watchdog_timout` attribute to set the watchdog timeout interval.

Session handling:

* [`src/napari_omero/widgets/gateway.py`](diffhunk://#diff-37dddf8857941f99100806af5557134fdbcaa82646967f414e7ab12b9524fe49R193-R195): Updated the `_on_new_session` method to start the connection watchdog in a separate thread using `create_worker` from `napari.qt.threading`.

Disconnection handling:

* [`src/napari_omero/widgets/main.py`](diffhunk://#diff-57a051b27c3519ddf8ab9bce45624ac7aa442f776a73da5784a83afeade22531R86): Connected the `disconnected` signal from the gateway to the `_on_disconnect` handler to manage UI changes on disconnection.

## Tested

I tested the approach by connecting to the OMERO instance I have access to and then cutting the VPN tunnel. It takes a few seconds for the plugin to fall back to the login view, but it does it :) That behavior can probably be tuned by setting better timeout values.