### PR TITLE
[Maint] Allow python to up 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,19 @@ jobs:
         platform: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         backend: [PyQt5]
+        exclude:
+          - platform: macos-13
+            python-version: "3.10"
+          - platform: macos-13
+            python-version: "3.11"
+          - platform: macos-latest
+            python-version: "3.10"
+          - platform: macos-latest
+            python-version: "3.11"
+          - platform: windows-latest
+            python-version: "3.10"
+          - platform: windows-latest
+            python-version: "3.11"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-13, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         backend: [PyQt5]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ pip install napari-omero[all]  # the [all] here is the same as `napari[all]`
   reports](https://github.com/tlambert03/napari-omero/issues/new) are welcome!
 - remote loading can be very slow still... though this is not strictly an issue
   of this plugin.  Datasets are wrapped as delayed dask stacks, and remote data
-  fetching time can be significant.  Plans for [asynchronous
-  rendering](https://napari.org/guides/stable/rendering.html) in
-  napari and
-  [tiled loading from OMERO](https://github.com/tlambert03/napari-omero/pull/1)
-  may eventually improve the subjective performance... but remote data loading
+  fetching time can be significant.  Enabling [asynchronous
+  rendering](https://napari.org/stable/guides/rendering.html#asynchronous-slicing) in
+  napari improves the subjective performance... but remote data loading
   will likely always be a limitation here.
-  To try asyncronous loading, start the program with `NAPARI_ASYNC=1 napari-omero`.
+  To try asyncronous loading, start the program with `NAPARI_ASYNC=1 napari-omero`
+  or look in the Preferences on the Experimental tab.
+  Also, keep an eye on the [napari progressive loading implementation progress](https://github.com/napari/napari/issues/5561).
 
 ## contributing
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ omero napari view Image:1
 
 While this package supports anything above python 3.9,
 In practice, python support is limited by `omero-py` and `zeroc-ice`,
-compatibility, which is limited to python <=3.10 at the time of writing.
+compatibility, which is limited to python <=3.12 at the time of writing.
 
 ### from conda
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,7 @@ filterwarnings = [
     "ignore:'U' mode is deprecated",
     "ignore:Please import PackageMetadata from 'npe2'",
     "ignore:`np.bool8` is a deprecated alias for `np.bool_`:DeprecationWarning:skimage",
+    "ignore:Pickle, copy, and deepcopy support will be removed from itertools in Python 3.14:DeprecationWarning"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Visualization",


### PR DESCRIPTION
As noted here: https://github.com/tlambert03/napari-omero/issues/82
zeroc-ice 3.6.5 on conda-forge supports up to python 3.12 now, so we can lift the restrictions.
This PR changes the metadata in pyproject, expands testing (3.9-3.12 on ubuntu, just top and bottom on macOS and windows), and updates the README.
At a minimum, once some iteration of this PR is released we will need to update the conda-forge recipe to change the python pin (https://github.com/conda-forge/napari-omero-feedstock/blob/07743f4ee515cd2762ea3d737102fd294102cf18/recipe/meta.yaml#L29)