### PR TITLE
Account for singleton dimensions, by squeezing them out and adjusting metadata accordingly

### DIFF
--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -88,11 +88,13 @@ def load_image_wrapper(image: ImageWrapper) -> list[LayerData]:
             for i in range(5)
             if i not in singleton_dims and i != 1
         ]
-        meta["axis_labels"] = [
-            meta["axis_labels"][non_channel_axes.index(i)]
-            for i in range(5)
-            if i not in singleton_dims and i != 1
-        ]
+        # TODO: axis_labels is a 0.5.0 and on feature
+        # re-enable this code once we're ready to break support for <0.5
+        # meta["axis_labels"] = [
+        #    meta["axis_labels"][non_channel_axes.index(i)]
+        #    for i in range(5)
+        #    if i not in singleton_dims and i != 1
+        #]
     # contrast limits range ... not accessible from plugin interface
     # win_min = channel.getWindowMin()
     # win_max = channel.getWindowMax()
@@ -124,7 +126,9 @@ def get_omero_metadata(image: ImageWrapper) -> dict:
 
     return {
         "channel_axis": 1,
-        "axis_labels": list("TZYX"),
+        # TODO: axis_labels is a 0.5.0 and on feature
+        # re-enable this code once we're ready to break support for <0.5
+        # "axis_labels": list("TZYX"),
         "colormap": colors,
         "contrast_limits": contrast_limits,
         "name": names,

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -94,7 +94,7 @@ def load_image_wrapper(image: ImageWrapper) -> list[LayerData]:
         #    meta["axis_labels"][non_channel_axes.index(i)]
         #    for i in range(5)
         #    if i not in singleton_dims and i != 1
-        #]
+        # ]
     # contrast limits range ... not accessible from plugin interface
     # win_min = channel.getWindowMin()
     # win_max = channel.getWindowMax()


### PR DESCRIPTION
Closes https://github.com/tlambert03/napari-omero/issues/62

In this PR, the data array is checked for singleton dimensions that are not C (C is the channel_axis, so napari splits it and it's squeezed out). These non-C singletons are squeezed and then the `scale` and `axis_labels` are updated to account for the dropped dims.
Note I added `axis_labels` to the metadata, because it made implementing and testing this *much* easier!
I would open an image in omeroweb and the same image in napari and look at:
```
for layer in viewer.layers
    print(layer.axis_labels, layer.data.shape, layer.scale)
```
This is a napari 0.5.0 and newer kwarg though, so we can drop it if we don't want to bump the min requirement.
Edit: I commented out the axis_labels usage so we don't break <0.5 with this minor release. We can do that with the multiscale PR.