### PR TITLE
Forces napari to always open images as Image layers

### DIFF
--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -99,7 +99,7 @@ def load_image_wrapper(image: ImageWrapper) -> list[LayerData]:
     # contrast limits range ... not accessible from plugin interface
     # win_min = channel.getWindowMin()
     # win_max = channel.getWindowMax()
-    return [(data, meta)]
+    return [(data, meta, 'image')]
 
 
 BASIC_COLORMAPS = {

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -99,7 +99,7 @@ def load_image_wrapper(image: ImageWrapper) -> list[LayerData]:
     # contrast limits range ... not accessible from plugin interface
     # win_min = channel.getWindowMin()
     # win_max = channel.getWindowMax()
-    return [(data, meta, 'image')]
+    return [(data, meta, "image")]
 
 
 BASIC_COLORMAPS = {


### PR DESCRIPTION
This PR offers a simple solution to open OMERO images always as a `Image` layer, avoiding the error described in #91 .