### PR TITLE
Add omero metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "napari>=0.4.13",
     "omero-py",
     "omero-rois",
+    "omero-marshal",
     # these come with napari ...
     # but are directly imported here as well so are included explicitly
     "qtpy>=1.10.0",

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -4,6 +4,7 @@ import dask.array as da
 from dask.delayed import delayed
 from napari.types import LayerData
 from napari.utils.colormaps import ensure_colormap
+from omero_marshal import get_encoder
 from vispy.color import Colormap
 
 from napari_omero.utils import PIXEL_TYPES, lookup_obj, parse_omero_url, timer
@@ -100,13 +101,6 @@ def load_image_wrapper(image: ImageWrapper) -> list[LayerData]:
     # win_min = channel.getWindowMin()
     # win_max = channel.getWindowMax()
 
-    # get json metadata
-    from omero_marshal import get_encoder
-
-    img_obj = image._obj
-    encoder = get_encoder(img_obj.__class__)
-
-    meta["metadata"] = {"omero": encoder.encode(img_obj)}
     return [(data, meta, "image")]
 
 
@@ -157,6 +151,11 @@ def get_omero_metadata(image: ImageWrapper) -> dict:
     # so we only need scale to have 4 elements
     scale = [1, size_z, size_y, size_x]
 
+    # get json metadata from omero
+    img_obj = image._obj
+    encoder = get_encoder(img_obj.__class__)
+    metadata = {"omero": encoder.encode(img_obj)}
+
     return {
         "channel_axis": 1,
         # TODO: axis_labels is a 0.5.0 and on feature
@@ -167,6 +166,7 @@ def get_omero_metadata(image: ImageWrapper) -> dict:
         "name": names,
         "visible": visibles,
         "scale": scale,
+        "metadata": metadata,
     }
 
 

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -99,6 +99,14 @@ def load_image_wrapper(image: ImageWrapper) -> list[LayerData]:
     # contrast limits range ... not accessible from plugin interface
     # win_min = channel.getWindowMin()
     # win_max = channel.getWindowMax()
+
+    # get json metadata
+    from omero_marshal import get_encoder
+
+    img_obj = image._obj
+    encoder = get_encoder(img_obj.__class__)
+
+    meta["metadata"] = {"omero": encoder.encode(img_obj)}
     return [(data, meta)]
 
 


### PR DESCRIPTION
Fixes #16 

This pull request includes updates to the `pyproject.toml` file and the `load_image_wrapper` function in `src/napari_omero/plugins/loaders.py` to enhance functionality with OMERO. It might be a bit overkill to just add all the omero metadata but I feel like it's cleanest to stay close to the metadata standards OME already provides for us.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R58): Added `omero-marshal` to the list of dependencies.

Functionality enhancements:

* [`src/napari_omero/plugins/loaders.py`](diffhunk://#diff-aff5e674ec54bcc0d4f442416df8ec684c314d7f2e8e1bf14e21b4561de9d1f9R102-R109): Updated the `load_image_wrapper` function to include JSON metadata encoding using `omero_marshal`.