### PR TITLE
Fix idle timeout

### DIFF
--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -63,7 +63,13 @@ def omero_proxy_reader(
     gateway = get_gateway(path)
 
     if proxy_obj.__class__.__name__.startswith("Image"):
-        wrapper = lookup_obj(gateway, proxy_obj)
+        try:
+            wrapper = lookup_obj(gateway, proxy_obj)
+        except Exception:
+            gateway = get_gateway(path, force_reconnect=True)
+            if not gateway:
+                return []
+            wrapper = lookup_obj(gateway, proxy_obj)
         if isinstance(wrapper, ImageWrapper):
             return load_image_wrapper(wrapper)
     return []

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -15,12 +15,17 @@ from omero.model import IObject
 
 
 # @timer
-def get_gateway(path: str, host: Optional[str] = None) -> BlitzGateway:
+def get_gateway(
+    path: str, host: Optional[str] = None, force_reconnect: bool = False
+) -> BlitzGateway:
     gateway = QGateWay()
     if host:
         if host != gateway.host:
             gateway.close()
         gateway.host = host
+
+    if force_reconnect:
+        gateway.conn = None
 
     if gateway.isConnected():
         return gateway.conn


### PR DESCRIPTION
Fixes #71 

This should be a much simpler way to avoid widget crashes due to disconnect errors (e.g., through idle timeouts). The root issue here is that the `QGateway` itself doesn't check whether it's connected in `gateway.isConnected()`. Really checking this there would also be quite a nuisance as that would come with a timeout for the check itself - which in turn introduces quite a lag into the image loading.

To fix it, I added a `force_reconnect` option to the function that retrieves the gateway (`utils > get_gateway`) that brings up a `LoginForm`. If this is passed correctly (shouldn't be difficult for an idle timeout), then the image loading resumes normally. This functionality is invoked by a simple `try-except` block in the reader function that retrieves the `image_wrapper` object.