### PR TITLE
Support named axes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 ]
 # add your package dependencies here
 dependencies = [
-    "napari>=0.4.13",
+    "napari>=0.5.0",
     "omero-py",
     "omero-rois",
     "omero-marshal",

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -5,7 +5,6 @@ from dask.delayed import delayed
 from napari.types import LayerData
 from napari.utils.colormaps import ensure_colormap
 from omero_marshal import get_encoder
-from vispy.color import Colormap
 
 from napari_omero.utils import PIXEL_TYPES, lookup_obj, parse_omero_url, timer
 from napari_omero.widgets import QGateWay
@@ -98,16 +97,7 @@ def get_omero_metadata(image: ImageWrapper) -> dict:
         if color.getHtml() in BASIC_COLORMAPS:
             colors.append(ensure_colormap(BASIC_COLORMAPS[color.getHtml()]))
         else:
-            try:
-                # requires 0.4.19 or later
-                # if the colormap exists in napari, use it
-                # otherwise, create a custom napari colormap
-                colors.append(ensure_colormap("#" + color.getHtml()))
-            except KeyError:
-                # on napari <0.4.19 use vispy colormap
-                color = color.getRGB()
-                color = [r / 256 for r in color]
-                colors.append(Colormap([[0, 0, 0], color]))
+            colors.append(ensure_colormap("#" + color.getHtml()))
 
     contrast_limits = [[ch.getWindowStart(), ch.getWindowEnd()] for ch in channels]
 

--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -134,6 +134,7 @@ def get_omero_metadata(image: ImageWrapper) -> dict:
         "visible": visibles,
         "scale": scale,
         "metadata": metadata,
+        "axis_labels": ("t", "z", "y", "x"),
     }
 
 


### PR DESCRIPTION
Relevant for #88:

This introduces a napari version pin of `>0.5.0` and sets the `axis_labels` property of images loaded from OMERO. This should make working with various dimensions a bit easier in the future.