### PR TITLE
prepend image id to layer

### DIFF
--- a/src/napari_omero/plugins/loaders.py
+++ b/src/napari_omero/plugins/loaders.py
@@ -127,7 +127,7 @@ def get_omero_metadata(image: ImageWrapper) -> dict:
     contrast_limits = [[ch.getWindowStart(), ch.getWindowEnd()] for ch in channels]
 
     visibles = [ch.isActive() for ch in channels]
-    names = [ch.getLabel() for ch in channels]
+    names = [f"{image.getId()}: {ch.getLabel()}" for ch in channels]
 
     size_x = image.getPixelSizeX() or 1
     size_y = image.getPixelSizeY() or 1


### PR DESCRIPTION
Fixes #98 

This prepends the omero image id to the respective layer name of each channel. Especially for multiple iamges open at the same time, this should make things a bit easier 👍 