### PR TITLE
Update pyproject.toml to not restrict vispy (drop it)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ dependencies = [
     # but are directly imported here as well so are included explicitly
     "qtpy>=1.10.0",
     "dask[array]>=2021.10.0",
-    "vispy>=0.14.1,<0.15",
     "superqt>=0.6.7",
 ]
 


### PR DESCRIPTION
We no longer import from vispy, so it's not a direct dependency, so it doesn't belong in our dependencies list.
Further, napari will soon move up to 0.15 in 0.6.1, so the upper bound on the current pin is potentially problematic in terms of compatibility.
We will need a release with this change before/around the release of 0.6.1