### PR TITLE
Update README.md to fix demo.gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ viewer for python.
 It provides a GUI interface for browsing an OMERO instance from within napari,
 as well as command line interface extensions for both OMERO and napari CLIs.
 
-![demo](https://github.com/tlambert03/napari-omero/blob/master/demo.gif?raw=true)
+![demo](https://github.com/tlambert03/napari-omero/blob/main/demo.gif?raw=true)
 
 ## Features
 


### PR DESCRIPTION
I did't even realize there was a GIF there until I saw the broken image link on napari-hub:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/0fcd2a28-463e-46bd-ab3b-6866aa0ab4d4" />

This PR fixes the link by using the right branch name.