### PR TITLE
Adding load function to load ROIs from Omero to Napari

### DIFF
--- a/src/napari_omero/widgets/ROIs.py
+++ b/src/napari_omero/widgets/ROIs.py
@@ -6,15 +6,43 @@ from napari.layers import Image, Labels
 from napari.utils.notifications import show_info
 
 from napari_omero.plugins.omero import save_rois
+from napari_omero.plugins.loaders import load_rois
 from napari_omero.utils import lookup_obj
+from magicgui.widgets import PushButton
 from omero.cli import ProxyStringType
 
 from .gateway import QGateWay
 
 
+def _init(widget):
+    load_button = PushButton(text="Load ROIs from OMERO")
+    widget.insert(1, load_button)
+    widget.load_button = load_button
+
+    @load_button.clicked.connect
+    def _load_rois_from_omero():
+        viewer = napari.viewer.current_viewer()
+        image_layer = viewer.layers.selection.active
+
+        if not image_layer or "omero" not in image_layer.metadata:
+            show_info("No OMERO metadata found in selected layer.")
+            return
+
+        gateway = QGateWay()
+        image_id = image_layer.metadata["omero"]["@id"]
+
+        image_wrapper = gateway.conn.getObject("Image", image_id)
+        roi_layers = load_rois(gateway.conn, image_wrapper)
+
+        for coords, meta, _ in roi_layers:
+            viewer.add_shapes(coords, **meta)
+
+        show_info(f"Loaded ROIs from OMERO image id {image_id}.")
+
 @magic_factory(
     omero_image={"label": "Layer from OMERO to annotate"},
     call_button="Upload Annotations to OMERO",
+    widget_init=_init
 )
 def save_rois_to_OMERO(omero_image: Image) -> None:
     """Upload annotations for a chosen image to OMERO.


### PR DESCRIPTION
This PR introduces the load_rois(conn, image) function in src/napari-omero/plugins/loaders.py.

- Load ROIs and their shapes directly from OMERO for a given image
- Convert OMERO shapes (via_parse_omero_shape()_ like rectangles, polygons, and ellipses) into the correct Napari coordinate system
- Add all these processed shapes to a single Napari shapes layer. Crucially, it also carries over essential metadata such as the ROI ID, shape ID, Z/T index, and any comments, keeping all the relevant info accessible right there in Napari
- Apply physical pixel scaling and visual styling (color, edge width)

**Issues:**

- Currently, the implementation creates separate ROIs for each Z/T index when these values are **none**. I'm exploring how to implement functionality that would represent a single OMERO ROI spanning all Z/T planes in Napari (i.e., a single ROI covering all planes)
- Additionally, if I use the Upload Annotation feature after loading ROIs, it results in duplicate ROIs being saved in OMERO. I plan to address this in a future PR

 Done under the guidance of @Tom-TBT