### PR TITLE
Add info to thumbgrid

### DIFF
--- a/src/napari_omero/widgets/thumb_grid.py
+++ b/src/napari_omero/widgets/thumb_grid.py
@@ -3,6 +3,7 @@ from typing import Optional
 from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QIcon, QImage, QPixmap
 from qtpy.QtWidgets import (
+    QHeaderView,
     QLabel,
     QListWidget,
     QListWidgetItem,
@@ -10,7 +11,6 @@ from qtpy.QtWidgets import (
     QTableWidgetItem,
     QVBoxLayout,
     QWidget,
-    QHeaderView
 )
 
 from .gateway import QGateWay
@@ -83,8 +83,6 @@ class ThumbItemWidget(QWidget):
         self.setMinimumWidth(icon_width)
         self.setMaximumWidth(192)
         self.setFixedHeight(icon_height + name_label.height() + table.height())
-
-
 
 
 class ThumbGrid(QListWidget):


### PR DESCRIPTION
Hi @psobolewskiPhD ,

small/medium change to the `OMEROBrowser` widget: It always bugged me that there was little additional information on the image data in the browser widget. I mean it's nice to have thumbnails, but if you are looking for a specific image that has or doesn't have specific metadata, it's a bit tricky to do.

#85 was one idea of going at it, which I tried and found quite hard to do. So I figured more information about the image data could just be added to the thumbgrid in the browser, like this:

<img width="2560" height="1392" alt="grafik" src="https://github.com/user-attachments/assets/44f7466a-e54b-42bf-9420-d451de1b8bab" />

For this, I made the thumbnails a bit larger and I still have to find a good way to make the table look good no matter how long the image title/dimensions/etc are but I think it could be a way to go. Also, thumbsize should be `96` and the icon resized in qt rather than quering the thumbnail in a different size than befor (for [this reason](https://forum.image.sc/t/speed-of-conn-getthumbnailset-in-omero-py-vs-omero-web/39328/2)) but that can yet be changed.

Other information to add to the info card could be
- Tags
- Does the image have ROIs/how many?

Looking forward to hearing your thoughts on this :)