### PR TITLE
Pass SERVICE_OPTS when saving ROIs

### DIFF
--- a/src/napari_omero/plugins/masks.py
+++ b/src/napari_omero/plugins/masks.py
@@ -13,7 +13,7 @@ def create_roi(image: ImageWrapper, shapes) -> RoiI:
     for shape in shapes:
         roi.addShape(shape)
     # Save the ROI (saves any linked shapes too)
-    return updateService.saveAndReturnObject(roi)
+    return updateService.saveAndReturnObject(roi, image._conn.SERVICE_OPTS)
 
 
 def save_labels(layer, image: ImageWrapper) -> list[RoiI]:

--- a/src/napari_omero/plugins/omero.py
+++ b/src/napari_omero/plugins/omero.py
@@ -168,6 +168,8 @@ def save_rois(viewer, image):
     >>> save_rois(viewer, omero_image).
     """
     conn = image._conn
+    group_id = image.getDetails().getGroup().getId()
+    conn.SERVICE_OPTS.setOmeroGroup(group_id)
 
     for layer in viewer.layers:
         if type(layer) is points_layer:
@@ -282,7 +284,7 @@ def create_roi(conn, img_id, shapes):
     roi.setImage(ImageI(img_id, False))
     for shape in shapes:
         roi.addShape(shape)
-    return updateService.saveAndReturnObject(roi)
+    return updateService.saveAndReturnObject(roi, conn.SERVICE_OPTS)
 
 
 class NonCachedPixelsWrapper(PixelsWrapper):


### PR DESCRIPTION
Update ROI saving functions to pass SERVICE_OPTS for group context, ensuring correct OMERO group is set when saving ROIs.

This should solve #120 