### PR TITLE
Refactor load/upload ROI widget

### DIFF
--- a/src/napari_omero/napari.yaml
+++ b/src/napari_omero/napari.yaml
@@ -5,9 +5,9 @@ contributions:
   - id: napari-omero.widget
     title: Open OMERO widget
     python_name: napari_omero.widgets.main:OMEROWidget
-  - id: napari-omero.upload_to_omero
+  - id: napari-omero.omero_roi_manager
     title: Load/Upload Annotations to OMERO
-    python_name: napari_omero.widgets:save_rois_to_OMERO
+    python_name: napari_omero.widgets:omero_roi_manager
   - id: napari-omero.get_reader
     title: OMERO reader
     python_name: napari_omero.plugins._napari:napari_get_reader
@@ -19,10 +19,10 @@ contributions:
     napari/file/io_utilities:
       - command: napari-omero.widget
         display_name: OMERO Browser
-      - command: napari-omero.upload_to_omero
+      - command: napari-omero.omero_roi_manager
         display_name: Load/Upload Annotations to OMERO
   widgets:
   - command: napari-omero.widget
     display_name: OMERO Browser
-  - command: napari-omero.upload_to_omero
+  - command: napari-omero.omero_roi_manager
     display_name: Load/Upload Annotations to OMERO

--- a/src/napari_omero/widgets/ROIs.py
+++ b/src/napari_omero/widgets/ROIs.py
@@ -1,28 +1,33 @@
 import warnings
 
 import napari.viewer
-from magicgui import magic_factory
-from magicgui.widgets import PushButton
+from magicgui.widgets import ComboBox, Container, PushButton
 from napari.layers import Image, Labels
 from napari.utils.notifications import show_info
+from omero.cli import ProxyStringType
 
 from napari_omero.plugins.loaders import load_rois
 from napari_omero.plugins.omero import save_rois
 from napari_omero.utils import lookup_obj
-from omero.cli import ProxyStringType
-
-from .gateway import QGateWay
+from napari_omero.widgets.gateway import QGateWay
 
 
-def _init(widget):
-    shape_load_button = PushButton(text="Load Annotations from OMERO")
-    widget.insert(1, shape_load_button)
-    widget.shape_load_button = shape_load_button
+def omero_roi_manager() -> Container:
+    """A widget to manage ROIs between napari and OMERO.
 
-    @shape_load_button.clicked.connect
-    def _load_rois_from_omero():
+    This widget handles both loading ROI from OMERO, as well as saving
+    napari annotations to OMERO as ROI.
+    """
+    omero_image_combobox = ComboBox(
+        label="OMERO Image", annotation=Image, name="omero_image"
+    )
+    load_button = PushButton(text="Load Annotations from OMERO")
+    save_button = PushButton(text="Upload Annotations to OMERO")
+
+    @load_button.clicked.connect
+    def _load_rois_from_omero() -> None:
         viewer = napari.viewer.current_viewer()
-        image_layer = widget.omero_image.value
+        image_layer = omero_image_combobox.value
 
         if not image_layer or "omero" not in image_layer.metadata:
             show_info("No OMERO metadata found in selected layer.")
@@ -48,46 +53,32 @@ def _init(widget):
         if points_meta:
             viewer.add_points(points_coords, **points_meta)
 
+    @save_button.clicked.connect
+    def _save_rois_to_omero() -> None:
+        omero_image = omero_image_combobox.value
+        # check if 'omero' field is in metadata
+        if not omero_image or "omero" not in omero_image.metadata:
+            warnings.warn("No OMERO metadata found in selected layer.", stacklevel=2)
+            return
 
-@magic_factory(
-    omero_image={"label": "OMERO ROI Manager"},
-    call_button="Upload Annotations to OMERO",
-    widget_init=_init,
-)
-def save_rois_to_OMERO(omero_image: Image) -> None:
-    """Upload annotations for a chosen image to OMERO.
+        # assert that layer is 4D if it is a labels layer
+        if isinstance(omero_image, Labels) and omero_image.ndim != 4:
+            raise ValueError(
+                "Labels layer must be 4D (time, z, y, x) to be uploaded to OMERO."
+            )
 
-    Parameters
-    ----------
-    omero_image: Image
-        An image layer loaded from OMERO.
-        Layer metadata has stored OMERO image ID.
-        Annotations will be uploaded to the OMERO server as ROI for that image ID.
+        gateway = QGateWay()
+        image_id = omero_image.metadata["omero"]["@id"]
 
-    Returns
-    -------
-    None
-    """
-    # check if 'omero' field is in metadata
-    if "omero" not in omero_image.metadata:
-        warnings.warn("No OMERO metadata found in selected layer.", stacklevel=2)
-        return
-
-    # assert that layer is 4D if it is a labels layer
-    if isinstance(omero_image, Labels) and omero_image.ndim != 4:
-        raise ValueError(
-            "Labels layer must be 4D (time, z, y, x) to be uploaded to OMERO."
+        image_wrapper = lookup_obj(
+            gateway.conn, ProxyStringType("Image")(f"Image:{image_id}")
         )
 
-    gateway = QGateWay()
-    image_id = omero_image.metadata["omero"]["@id"]
+        viewer = napari.viewer.current_viewer()
+        save_rois(viewer=viewer, image=image_wrapper)
 
-    image_wrapper = lookup_obj(
-        gateway.conn, ProxyStringType("Image")(f"Image:{image_id}")
-    )
+        trg = image_wrapper.getName()
+        show_info(f"All annotation layers uploaded to OMERO image id {image_id}: {trg}")
 
-    viewer = napari.viewer.current_viewer()
-    save_rois(viewer=viewer, image=image_wrapper)
-
-    trg = image_wrapper.getName()
-    show_info(f"All annotation layers uploaded to OMERO image id {image_id}: {trg}")
+    container = Container(widgets=[omero_image_combobox, load_button, save_button])
+    return container

--- a/src/napari_omero/widgets/ROIs.py
+++ b/src/napari_omero/widgets/ROIs.py
@@ -1,7 +1,7 @@
 import warnings
 
 import napari.viewer
-from magicgui.widgets import ComboBox, Container, PushButton
+from magicgui.widgets import Container, PushButton, create_widget
 from napari.layers import Image, Labels
 from napari.utils.notifications import show_info
 
@@ -18,9 +18,7 @@ def omero_roi_manager() -> Container:
     This widget handles both loading ROI from OMERO, as well as saving
     napari annotations to OMERO as ROI.
     """
-    omero_image_combobox = ComboBox(
-        label="OMERO Image", annotation=Image, name="omero_image"
-    )
+    omero_image_combobox = create_widget(label="OMERO Image", annotation=Image)
     load_button = PushButton(text="Load Annotations from OMERO")
     save_button = PushButton(text="Upload Annotations to OMERO")
 

--- a/src/napari_omero/widgets/ROIs.py
+++ b/src/napari_omero/widgets/ROIs.py
@@ -4,12 +4,12 @@ import napari.viewer
 from magicgui.widgets import ComboBox, Container, PushButton
 from napari.layers import Image, Labels
 from napari.utils.notifications import show_info
-from omero.cli import ProxyStringType
 
 from napari_omero.plugins.loaders import load_rois
 from napari_omero.plugins.omero import save_rois
 from napari_omero.utils import lookup_obj
 from napari_omero.widgets.gateway import QGateWay
+from omero.cli import ProxyStringType
 
 
 def omero_roi_manager() -> Container:

--- a/src/napari_omero/widgets/__init__.py
+++ b/src/napari_omero/widgets/__init__.py
@@ -1,6 +1,6 @@
 from .gateway import QGateWay
 from .login import LoginForm
 from .main import OMEROWidget
-from .ROIs import save_rois_to_OMERO
+from .ROIs import omero_roi_manager
 
-__all__ = ["LoginForm", "OMEROWidget", "QGateWay", "save_rois_to_OMERO"]
+__all__ = ["LoginForm", "OMEROWidget", "QGateWay", "omero_roi_manager"]


### PR DESCRIPTION
Closes: https://github.com/tlambert03/napari-omero/issues/125

This PR does not change functionality, it's just a refactor.
Instead of using magic_factory and widget_init, I use magicgui Container.
I think this is cleaner and easier to follow, with two functions connected to buttons.

I also renamed things in napari.yaml and the init to account for the fact that now we can upload and download stuff.