### PR TITLE
Update macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-15-intel, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         backend: [PyQt5]
         exclude:
-          - platform: macos-13
+          - platform: macos-15-intel
             python-version: "3.10"
-          - platform: macos-13
+          - platform: macos-15-intel
             python-version: "3.11"
           - platform: macos-latest
             python-version: "3.10"


### PR DESCRIPTION
macos-13 runners are retired.
See errors: https://github.com/ome/napari-omero/actions/runs/20753715801/job/59589813484?pr=112
https://github.com/actions/runner-images/issues/13046

This bumps to macOS-15-intel runners.