### PR TITLE
Don't generate thumbnails if only an image is selected

### DIFF
--- a/src/napari_omero/widgets/thumb_grid.py
+++ b/src/napari_omero/widgets/thumb_grid.py
@@ -30,19 +30,17 @@ class ThumbGrid(QListWidget):
 
         self._current_item = item
 
-        dataset = None
         if item.isDataset():
-            dataset = item
+            self.set_dataset(item)
+            self.show()
         elif item.isImage():
-            dataset = item.parent()
+            # Only highlight the thumbnail if its dataset's thumbnails are
+            # already loaded (i.e. the dataset was previously selected).
+            # Selecting an image shouldn't trigger thumbnail generation
+            if item.parent() == self._current_dataset:
+                self.select_image()
         else:
             self._current_dataset = None
-
-        if dataset:
-            self.set_dataset(dataset)
-            self.show()
-        if item.isImage():
-            self.select_image()
 
     def select_image(self):
         if self._current_item is not None:


### PR DESCRIPTION
This is a small list/tree view change that essentially canonicalizes the current behavior.
Currently, if you *expand* a dataset, but don't select it, the thumbnails are not generated. You can see the list of images. 
If you *select* a dataset, it will load the thumbnails.
So far so good.

But if you expand the dataset -- no thumbnails -- and then you click select an image, it will load the image and the thumbnails, which appears to hinder performance.

So with this change, thumbnails are loaded only if you click the dataset to select it.
So basically, it allows browsing without generating thumbnails -- for large datasets, this can be a nuisance if you don't want it to happen.

Yes, this is basically the opposite of https://github.com/ome/napari-omero/pull/74 but again for datasets with a lot of images the thumbnails aren't always desired.